### PR TITLE
Remove redirect_uri

### DIFF
--- a/gather_keys_oauth2.py
+++ b/gather_keys_oauth2.py
@@ -24,7 +24,7 @@ class OAuth2Server:
         self.fitbit = Fitbit(
             client_id,
             client_secret,
-            redirect_uri=redirect_uri,
+            redirect_uri,
             timeout=10,
         )
 


### PR DESCRIPTION
I was trying to get authorized but Fitbit server spitted an error that redirect_uri is giving bad arguments. 
And I figured out that giving redirect_uri value is wrong. Just use that given argument works.